### PR TITLE
fix: initially log some client connection, response errors at INFO level

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,10 +500,11 @@ Note: This service does not update data in this zone instance -
 many of the thermostat services do so.
 This service returns a bool indicating if it completed successfully.
 
-| Service data attribute | Optional | Default | Description                                    |
-| ---------------------- | -------- | ------- | ---------------------------------------------- |
-| `polling_delay`        | yes      | 5.0     | seconds to wait before each polling attempt    |
-| `max_polls`            | yes      | 8       | maximum number of times to poll for completion |
+| Service data attribute | Optional | Default | Description                                                   |
+| ---------------------- | -------- | ------- | ------------------------------------------------------------- |
+| `polling_delay`        | yes      | 5.0     | seconds to wait before each polling attempt                   |
+| `max_polls`            | yes      | 8       | maximum number of times to poll for completion                |
+| `raise_on_timeout`     | yes      | `False` | raise `TimeoutError` instead of logging and returning `False` |
 
 ### Service `add_room_iq_monitor`
 

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+from http import HTTPStatus
 from typing import Any
 
 import aiohttp
@@ -49,6 +50,13 @@ BRAND_TO_URL = {
     BRAND_TRANE: TRANE_ROOT_URL,
     BRAND_NEXIA: NEXIA_ROOT_URL,
 }
+
+MAX_INFO_LOG_FAILS = 4
+INFO_LOG_EXCEPTIONS: tuple[type[Exception], ...] = (
+    TimeoutError,
+    aiohttp.ClientConnectionError,
+)
+INFO_LOG_STATUSES = {HTTPStatus.SERVICE_UNAVAILABLE}
 
 
 def extract_children_from_devices_json(
@@ -411,24 +419,39 @@ class NexiaHome:
 
     async def _load_current_room_iq_states(self) -> None:
         """Load the current state of all monitored zones' RoomIQ sensors in parallel."""
-        load_current_sensor_state_coroutines = (
-            zone.load_current_sensor_state()
+        monitored_zones = [
+            zone
             for therm in self.thermostats
             for zone in therm.zones
             if zone.has_room_iq_monitor()
-        )
+        ]
         results = await asyncio.gather(
-            *load_current_sensor_state_coroutines, return_exceptions=True
+            *(
+                zone.load_current_sensor_state(handle_timeouts=False)
+                for zone in monitored_zones
+            ),
+            return_exceptions=True,
         )
-        for result in results:
-            if isinstance(result, Exception):
+        for zone, result in zip(monitored_zones, results, strict=True):
+            if result is True:
+                zone.consecutive_load_sensor_fails = 0
+            else:
+                zone.consecutive_load_sensor_fails += 1
+
+            if isinstance(result, BaseException):
                 # stale data beats no data - just log this and continue
-                _LOGGER.exception(
-                    "Failed to load RoomIQ sensor state: Exception %s: %s",
-                    result.__class__.__name__,
-                    str(result),
-                    exc_info=result,
+                info = isinstance(result, INFO_LOG_EXCEPTIONS) or (
+                    isinstance(result, aiohttp.ClientResponseError)
+                    and result.status in INFO_LOG_STATUSES
                 )
+                if info and zone.consecutive_load_sensor_fails <= MAX_INFO_LOG_FAILS:
+                    level = logging.INFO
+                else:
+                    level = logging.ERROR
+                msg = "Failed to load RoomIQ sensor for zone %s: Exception %s: %s"
+                z_name = zone.get_name()
+                e_name = result.__class__.__name__
+                _LOGGER.log(level, msg, z_name, e_name, str(result), exc_info=result)
 
     async def update(self, force_update: bool = True) -> dict[str, Any] | None:
         """Updates the nexia status.

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -54,9 +54,14 @@ BRAND_TO_URL = {
 MAX_INFO_LOG_FAILS = 4
 INFO_LOG_EXCEPTIONS: tuple[type[Exception], ...] = (
     TimeoutError,
+    asyncio.TimeoutError,
     aiohttp.ClientConnectionError,
 )
-INFO_LOG_STATUSES = {HTTPStatus.SERVICE_UNAVAILABLE}
+INFO_LOG_STATUSES = {
+    HTTPStatus.BAD_GATEWAY,
+    HTTPStatus.SERVICE_UNAVAILABLE,
+    HTTPStatus.GATEWAY_TIMEOUT,
+}
 
 
 def extract_children_from_devices_json(
@@ -427,7 +432,7 @@ class NexiaHome:
         ]
         results = await asyncio.gather(
             *(
-                zone.load_current_sensor_state(handle_timeouts=False)
+                zone.load_current_sensor_state(raise_on_timeout=True)
                 for zone in monitored_zones
             ),
             return_exceptions=True,
@@ -446,12 +451,14 @@ class NexiaHome:
                 )
                 if info and zone.consecutive_load_sensor_fails <= MAX_INFO_LOG_FAILS:
                     level = logging.INFO
+                    e_info = None
                 else:
                     level = logging.ERROR
+                    e_info = result
                 msg = "Failed to load RoomIQ sensor for zone %s: Exception %s: %s"
                 z_name = zone.get_name()
                 e_name = result.__class__.__name__
-                _LOGGER.log(level, msg, z_name, e_name, str(result), exc_info=result)
+                _LOGGER.log(level, msg, z_name, e_name, str(result), exc_info=e_info)
 
     async def update(self, force_update: bool = True) -> dict[str, Any] | None:
         """Updates the nexia status.

--- a/nexia/home.py
+++ b/nexia/home.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+from collections import Counter
 from http import HTTPStatus
 from typing import Any
 
@@ -144,6 +145,7 @@ class NexiaHome:
         self.loop = asyncio.get_running_loop()
         self.log_response = True
         self._update_in_progress: asyncio.Future[None] | None = None
+        self._consecutive_room_iq_load_fails: Counter[str | int] = Counter()
 
     @property
     def API_MOBILE_PHONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -438,10 +440,9 @@ class NexiaHome:
             return_exceptions=True,
         )
         for zone, result in zip(monitored_zones, results, strict=True):
-            if result is True:
-                zone.consecutive_load_sensor_fails = 0
-            else:
-                zone.consecutive_load_sensor_fails += 1
+            fails = self._consecutive_room_iq_load_fails
+            consecutive_fails = 0 if result is True else fails[zone.zone_id] + 1
+            fails[zone.zone_id] = consecutive_fails
 
             if isinstance(result, BaseException):
                 # stale data beats no data - just log this and continue
@@ -449,7 +450,7 @@ class NexiaHome:
                     isinstance(result, aiohttp.ClientResponseError)
                     and result.status in INFO_LOG_STATUSES
                 )
-                if info and zone.consecutive_load_sensor_fails <= MAX_INFO_LOG_FAILS:
+                if info and consecutive_fails <= MAX_INFO_LOG_FAILS:
                     level = logging.INFO
                     e_info = None
                 else:

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -132,7 +132,6 @@ class NexiaThermostatZone:
         self.thermostat = nexia_thermostat
         self.zone_id = make_zone_id(nexia_thermostat, zone_json)
         self._room_iq_monitors: set[str] = set()
-        self.consecutive_load_sensor_fails = 0
 
     @property
     def API_MOBILE_ZONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -678,7 +677,10 @@ class NexiaThermostatZone:
         )
 
     async def load_current_sensor_state(
-        self, polling_delay=5.0, max_polls=8, raise_on_timeout=False
+        self,
+        polling_delay: float = 5.0,
+        max_polls: int = 8,
+        raise_on_timeout: bool = False,
     ) -> bool:
         """Load the current state of a zone's sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -640,17 +640,12 @@ class NexiaThermostatZone:
             )
 
     async def select_room_iq_sensors(
-        self,
-        active_sensor_ids: Iterable[int],
-        polling_delay=5.0,
-        max_polls=8,
-        handle_timeouts=True,
+        self, active_sensor_ids: Iterable[int], polling_delay=5.0, max_polls=8
     ) -> bool:
         """Select which RoomIQ sensors are included in the zone average.
         :param active_sensor_ids: collection of RoomIQ sensor identifiers to form the zone average
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
-        :param handle_timeouts: handle timeout exceptions here
         :return: bool indicating completed
         """
         if not active_sensor_ids:
@@ -679,16 +674,16 @@ class NexiaThermostatZone:
             "selecting active sensors",
             polling_delay,
             max_polls,
-            handle_timeouts,
+            raise_on_timeout=False,
         )
 
     async def load_current_sensor_state(
-        self, polling_delay=5.0, max_polls=8, handle_timeouts=True
+        self, polling_delay=5.0, max_polls=8, raise_on_timeout=False
     ) -> bool:
         """Load the current state of a zone's sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
-        :param handle_timeouts: handle timeout exceptions here
+        :param raise_on_timeout: raise TimeoutError instead of logging and returning False
         :return: bool indicating completed
         """
         req_cur_state = self.API_MOBILE_ZONE_URL.format(
@@ -700,7 +695,7 @@ class NexiaThermostatZone:
             "loading current sensor state",
             polling_delay,
             max_polls,
-            handle_timeouts,
+            raise_on_timeout,
         )
 
     async def _post_and_await_async_completion(
@@ -710,7 +705,7 @@ class NexiaThermostatZone:
         target: str,
         polling_delay: float,
         max_polls: int,
-        handle_timeouts: bool,
+        raise_on_timeout: bool,
     ) -> bool:
         """Post a request that returns an asynchronous url to poll for completion.
         :param request_url: url for service being requested
@@ -718,7 +713,7 @@ class NexiaThermostatZone:
         :param target: description of what is being accomplished
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
-        :param handle_timeouts: handle timeouts here
+        :param raise_on_timeout: raise TimeoutError instead of logging and returning False
         :return: bool indicating completed
         """
         async with await self._nexia_home.post_url(request_url, json_data) as response:
@@ -744,12 +739,12 @@ class NexiaThermostatZone:
             attempts -= 1
         # end while waiting for status
 
-        if handle_timeouts:
-            msg = "Gave up waiting while %s for zone %s"
-            _LOGGER.error(msg, target, self.get_name())
-            return False
+        if raise_on_timeout:
+            raise TimeoutError(f"Gave up waiting while {target}")
 
-        raise TimeoutError(f"Gave up waiting while {target}")
+        msg = "Gave up waiting while %s for zone %s"
+        _LOGGER.error(msg, target, self.get_name())
+        return False
 
     def add_room_iq_monitor(self, monitor_id: str) -> None:
         """Register a subscriber for this zone's RoomIQ sensor state updates.

--- a/nexia/zone.py
+++ b/nexia/zone.py
@@ -132,6 +132,7 @@ class NexiaThermostatZone:
         self.thermostat = nexia_thermostat
         self.zone_id = make_zone_id(nexia_thermostat, zone_json)
         self._room_iq_monitors: set[str] = set()
+        self.consecutive_load_sensor_fails = 0
 
     @property
     def API_MOBILE_ZONE_URL(self) -> str:  # pylint: disable=invalid-name
@@ -639,12 +640,17 @@ class NexiaThermostatZone:
             )
 
     async def select_room_iq_sensors(
-        self, active_sensor_ids: Iterable[int], polling_delay=5.0, max_polls=8
+        self,
+        active_sensor_ids: Iterable[int],
+        polling_delay=5.0,
+        max_polls=8,
+        handle_timeouts=True,
     ) -> bool:
         """Select which RoomIQ sensors are included in the zone average.
         :param active_sensor_ids: collection of RoomIQ sensor identifiers to form the zone average
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
+        :param handle_timeouts: handle timeout exceptions here
         :return: bool indicating completed
         """
         if not active_sensor_ids:
@@ -673,19 +679,28 @@ class NexiaThermostatZone:
             "selecting active sensors",
             polling_delay,
             max_polls,
+            handle_timeouts,
         )
 
-    async def load_current_sensor_state(self, polling_delay=5.0, max_polls=8) -> bool:
+    async def load_current_sensor_state(
+        self, polling_delay=5.0, max_polls=8, handle_timeouts=True
+    ) -> bool:
         """Load the current state of a zone's sensors into the physical thermostat.
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
+        :param handle_timeouts: handle timeout exceptions here
         :return: bool indicating completed
         """
         req_cur_state = self.API_MOBILE_ZONE_URL.format(
             end_point="request_current_sensor_state", zone_id=self.zone_id
         )
         return await self._post_and_await_async_completion(
-            req_cur_state, {}, "loading current sensor state", polling_delay, max_polls
+            req_cur_state,
+            {},
+            "loading current sensor state",
+            polling_delay,
+            max_polls,
+            handle_timeouts,
         )
 
     async def _post_and_await_async_completion(
@@ -695,6 +710,7 @@ class NexiaThermostatZone:
         target: str,
         polling_delay: float,
         max_polls: int,
+        handle_timeouts: bool,
     ) -> bool:
         """Post a request that returns an asynchronous url to poll for completion.
         :param request_url: url for service being requested
@@ -702,6 +718,7 @@ class NexiaThermostatZone:
         :param target: description of what is being accomplished
         :param polling_delay: seconds to wait before each polling attempt
         :param max_polls: maximum number of times to poll for completion
+        :param handle_timeouts: handle timeouts here
         :return: bool indicating completed
         """
         async with await self._nexia_home.post_url(request_url, json_data) as response:
@@ -721,13 +738,18 @@ class NexiaThermostatZone:
                 status = json.loads(payload)["status"]
 
                 if status != "success":
-                    _LOGGER.error("Unexpected status [%s] %s", status, target)
+                    msg = "Unexpected status [%s] %s for zone %s"
+                    _LOGGER.error(msg, status, target, self.get_name())
                 return True
             attempts -= 1
         # end while waiting for status
 
-        _LOGGER.error("Gave up waiting while %s", target)
-        return False
+        if handle_timeouts:
+            msg = "Gave up waiting while %s for zone %s"
+            _LOGGER.error(msg, target, self.get_name())
+            return False
+
+        raise TimeoutError(f"Gave up waiting while {target}")
 
     def add_room_iq_monitor(self, monitor_id: str) -> None:
         """Register a subscriber for this zone's RoomIQ sensor state updates.

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -7,7 +7,7 @@ import logging
 import os
 from os.path import dirname
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -15,6 +15,7 @@ from aiointercept import aiointercept
 from yarl import URL
 
 from nexia.home import (
+    MAX_INFO_LOG_FAILS,
     LoginFailedException,
     NexiaHome,
     _extract_devices_from_houses_json,
@@ -1413,17 +1414,28 @@ async def test_sensor_access(
     nexia.log_response = False
 
     # execute no completion code path
+    polling_url = "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa50000000"
     mock_aioresponse.post(
         "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state",
         payload={
             "success": True,
             "error": None,
-            "result": {
-                "polling_path": "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa50000000"
-            },
+            "result": {"polling_path": polling_url},
         },
     )
     assert await zone.load_current_sensor_state(max_polls=0) is False
+    mock_aioresponse.post(
+        "https://www.mynexia.com/mobile/xxl_zones/85034552/request_current_sensor_state",
+        payload={
+            "success": True,
+            "error": None,
+            "result": {"polling_path": polling_url},
+        },
+    )
+    with pytest.raises(
+        TimeoutError, match="Gave up waiting while loading current sensor state"
+    ):
+        await zone.load_current_sensor_state(max_polls=0, handle_timeouts=False)
 
     # execute normal code path
     polling_url = "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5"
@@ -1439,7 +1451,7 @@ async def test_sensor_access(
     mock_aioresponse.get(
         polling_url,
         payload={
-            "status": "success, altered to enhance test coverage",
+            "status": "success",
             "options": {},
         },
     )
@@ -1540,15 +1552,85 @@ async def test_room_iq_sensor_monitor(
 
         # Make sure we update current sensor state now
         assert await nexia.update() is not None
-        mock_load_current_sensor_state.assert_awaited_once_with()
+        mock_load_current_sensor_state.assert_awaited_once_with(handle_timeouts=False)
 
         # Force exception path
-        mock_load_current_sensor_state.side_effect = aiohttp.ServerTimeoutError
+        mock_load_current_sensor_state.side_effect = asyncio.InvalidStateError
         assert await nexia.update() is not None
+        assert mock_load_current_sensor_state.await_count == 2
 
     # Remove the last one
     zone.remove_room_iq_monitor("sensor.center_roomiq_temperature")
     assert nexia.any_room_iq_monitors() is False
+
+
+@patch("logging.Logger.log")
+@patch("nexia.zone.NexiaThermostatZone.load_current_sensor_state")
+async def test_room_iq_sensor_exception(
+    mock_load_sensor: AsyncMock,
+    mock_log: MagicMock,
+    aiohttp_session: aiohttp.ClientSession,
+    mock_aioresponse: aiointercept,
+) -> None:
+    """Test exception handling on RoomIQ sensor update."""
+    nexia = NexiaHome(aiohttp_session, house_id=2582941)
+    nexia.mobile_id = 5400000
+
+    mock_aioresponse.get(
+        "https://www.mynexia.com/mobile/houses/2582941",
+        body=await load_fixture("sensors_xl1050_house.json"),
+        repeat=True,
+    )
+
+    # Add a monitor
+    assert await nexia.update() is not None
+    zone = nexia.get_thermostat_by_id(5378307).get_zone_by_id(85034552)
+    zone.add_room_iq_monitor("sensor.upstairs_roomiq_humidity")
+    mock_log.assert_not_called()
+
+    # Test log level on exception paths
+    e_msg = "Gave up waiting while loading current sensor state"
+    mock_load_sensor.side_effect = TimeoutError(e_msg)
+    assert await nexia.update() is not None
+    mock_load_sensor.assert_awaited_once()
+    msg = "Failed to load RoomIQ sensor for zone %s: Exception %s: %s"
+    z_name = "Center NativeZone"
+    e_name = "TimeoutError"
+    args = [msg, z_name, e_name, e_msg]
+    mock_log.assert_called_with(logging.INFO, *args, **mock_log.call_args.kwargs)
+
+    mock_load_sensor.side_effect = asyncio.InvalidStateError
+    assert await nexia.update() is not None
+    args[2] = "InvalidStateError"
+    args[3] = ""
+    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+
+    mock_load_sensor.side_effect = aiohttp.ClientResponseError(
+        request_info=Mock(), history=(), status=500, message="mock error"
+    )
+    mock_load_sensor.side_effect.request_info.real_url = "mock:url"
+    assert await nexia.update() is not None
+    args[2] = "ClientResponseError"
+    args[3] = "500, message='mock error', url='mock:url'"
+    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+
+    mock_load_sensor.side_effect.status = 503
+    assert await nexia.update() is not None
+    args[3] = "503, message='mock error', url='mock:url'"
+    mock_log.assert_called_with(logging.INFO, *args, **mock_log.call_args.kwargs)
+
+    # Cause too many consecutive fails
+    assert zone.consecutive_load_sensor_fails == MAX_INFO_LOG_FAILS
+    assert await nexia.update() is not None
+    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+
+    # Test return True path
+    mock_load_sensor.side_effect = None
+    mock_load_sensor.return_value = True
+    mock_log.reset_mock()
+    assert await nexia.update() is not None
+    assert zone.consecutive_load_sensor_fails == 0
+    mock_log.assert_not_called()
 
 
 async def test_clamp_to_predefined_values() -> None:

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1622,7 +1622,7 @@ async def test_room_iq_sensor_exception(
     mock_log.assert_called_with(logging.INFO, *args, exc_info=None)
 
     # Cause too many consecutive fails
-    assert zone.consecutive_load_sensor_fails == MAX_INFO_LOG_FAILS
+    assert nexia._consecutive_room_iq_load_fails[zone.zone_id] == MAX_INFO_LOG_FAILS
     assert await nexia.update() is not None
     mock_log.assert_called_with(logging.ERROR, *args, **kwargs)
 
@@ -1631,7 +1631,7 @@ async def test_room_iq_sensor_exception(
     mock_load_sensor.return_value = True
     mock_log.reset_mock()
     assert await nexia.update() is not None
-    assert zone.consecutive_load_sensor_fails == 0
+    assert nexia._consecutive_room_iq_load_fails[zone.zone_id] == 0
     mock_log.assert_not_called()
 
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1435,7 +1435,7 @@ async def test_sensor_access(
     with pytest.raises(
         TimeoutError, match="Gave up waiting while loading current sensor state"
     ):
-        await zone.load_current_sensor_state(max_polls=0, handle_timeouts=False)
+        await zone.load_current_sensor_state(max_polls=0, raise_on_timeout=True)
 
     # execute normal code path
     polling_url = "https://www.mynexia.com/backstage/announcements/6a31e745716789b84603036489fe8d1e35ca80fa5dd381e5"
@@ -1552,7 +1552,7 @@ async def test_room_iq_sensor_monitor(
 
         # Make sure we update current sensor state now
         assert await nexia.update() is not None
-        mock_load_current_sensor_state.assert_awaited_once_with(handle_timeouts=False)
+        mock_load_current_sensor_state.assert_awaited_once_with(raise_on_timeout=True)
 
         # Force exception path
         mock_load_current_sensor_state.side_effect = asyncio.InvalidStateError
@@ -1597,13 +1597,14 @@ async def test_room_iq_sensor_exception(
     z_name = "Center NativeZone"
     e_name = "TimeoutError"
     args = [msg, z_name, e_name, e_msg]
-    mock_log.assert_called_with(logging.INFO, *args, **mock_log.call_args.kwargs)
+    mock_log.assert_called_with(logging.INFO, *args, exc_info=None)
 
-    mock_load_sensor.side_effect = asyncio.InvalidStateError
+    mock_load_sensor.side_effect = asyncio.InvalidStateError()
     assert await nexia.update() is not None
     args[2] = "InvalidStateError"
     args[3] = ""
-    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+    kwargs = {"exc_info": mock_load_sensor.side_effect}
+    mock_log.assert_called_with(logging.ERROR, *args, **kwargs)
 
     mock_load_sensor.side_effect = aiohttp.ClientResponseError(
         request_info=Mock(), history=(), status=500, message="mock error"
@@ -1612,17 +1613,18 @@ async def test_room_iq_sensor_exception(
     assert await nexia.update() is not None
     args[2] = "ClientResponseError"
     args[3] = "500, message='mock error', url='mock:url'"
-    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+    kwargs = {"exc_info": mock_load_sensor.side_effect}
+    mock_log.assert_called_with(logging.ERROR, *args, **kwargs)
 
     mock_load_sensor.side_effect.status = 503
     assert await nexia.update() is not None
     args[3] = "503, message='mock error', url='mock:url'"
-    mock_log.assert_called_with(logging.INFO, *args, **mock_log.call_args.kwargs)
+    mock_log.assert_called_with(logging.INFO, *args, exc_info=None)
 
     # Cause too many consecutive fails
     assert zone.consecutive_load_sensor_fails == MAX_INFO_LOG_FAILS
     assert await nexia.update() is not None
-    mock_log.assert_called_with(logging.ERROR, *args, **mock_log.call_args.kwargs)
+    mock_log.assert_called_with(logging.ERROR, *args, **kwargs)
 
     # Test return True path
     mock_load_sensor.side_effect = None


### PR DESCRIPTION
To avoid filling logs with transient error messages, change the log level for some errors known to occur during temporary service outages from `ERROR` to `INFO`. This change only effects the first 4 consecutive occurances for a zone -- after which all errors log at `ERROR` level.

This is ispired by observing error logs when running nexia under Home Assistant.